### PR TITLE
feat: add push notification level toggle (critical vs all updates)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,6 +87,7 @@ export default function Dashboard() {
   const [isClient, setIsClient] = useState(false);
   const [prevCriticalCount, setPrevCriticalCount] = useState(0);
   const [soundEnabled, setSoundEnabled] = useState(false);
+  const [notificationLevel, setNotificationLevel] = useState<'all' | 'critical'>('critical');
   const [mobileView, setMobileView] = useState<MobileView>('feed');
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [tvMode, setTvMode] = useState(false);
@@ -155,9 +156,12 @@ export default function Dashboard() {
   const militaryCount = signals.filter(s => s.category === 'military').length;
 
   useEffect(() => {
-    if (soundEnabled && criticalCount > prevCriticalCount && prevCriticalCount > 0) playAlertSound();
-    setPrevCriticalCount(criticalCount);
-  }, [criticalCount, soundEnabled, prevCriticalCount]);
+    const relevantCount = notificationLevel === 'all'
+      ? signals.filter(s => s.severity === 'CRITICAL' || s.severity === 'HIGH').length
+      : criticalCount;
+    if (soundEnabled && relevantCount > prevCriticalCount && prevCriticalCount > 0) playAlertSound();
+    setPrevCriticalCount(relevantCount);
+  }, [criticalCount, soundEnabled, prevCriticalCount, notificationLevel, signals]);
 
   const handleLayerToggle = useCallback((layer: string) => {
     setActiveLayers(prev => prev.includes(layer) ? prev.filter(l => l !== layer) : [...prev, layer]);
@@ -304,6 +308,13 @@ export default function Dashboard() {
           >
             {soundEnabled ? '🔔' : '🔕'} ALERTS
           </button>
+          <button
+            onClick={() => setNotificationLevel(notificationLevel === 'critical' ? 'all' : 'critical')}
+            className={`flex items-center gap-1.5 px-2 py-1 rounded text-[9px] font-mono ${notificationLevel === 'all' ? 'bg-accent-blue/20 text-accent-blue' : 'bg-elevated text-text-dim'}`}
+            title={notificationLevel === 'critical' ? 'Only Critical notifications' : 'All updates notifications'}
+          >
+            {notificationLevel === 'critical' ? '🔴' : '🔵'} {notificationLevel === 'critical' ? 'CRIT' : 'ALL'}
+          </button>
         </div>
         <div className="flex-1 overflow-hidden">
           <WarRoom signals={signals} conflicts={conflicts} />
@@ -328,7 +339,7 @@ export default function Dashboard() {
       <TVMode isActive={tvMode} onExit={() => setTvMode(false)} />
 
       {/* Breaking News Banner */}
-      <BreakingNewsBanner signals={signals} />
+      <BreakingNewsBanner signals={signals} notificationLevel={notificationLevel} />
 
       {/* Mode Toggle - Desktop */}
       <div className="hidden lg:flex bg-void border-b border-border-default px-4 py-1.5 items-center justify-between">
@@ -367,6 +378,13 @@ export default function Dashboard() {
             className={`flex items-center gap-1.5 px-2 py-1 rounded text-[9px] font-mono ${soundEnabled ? 'bg-accent-green/20 text-accent-green' : 'bg-elevated text-text-dim'}`}
           >
             {soundEnabled ? '🔔' : '🔕'} ALERTS
+          </button>
+          <button
+            onClick={() => setNotificationLevel(notificationLevel === 'critical' ? 'all' : 'critical')}
+            className={`flex items-center gap-1.5 px-2 py-1 rounded text-[9px] font-mono ${notificationLevel === 'all' ? 'bg-accent-blue/20 text-accent-blue' : 'bg-elevated text-text-dim'}`}
+            title={notificationLevel === 'critical' ? 'Only Critical notifications' : 'All updates notifications'}
+          >
+            {notificationLevel === 'critical' ? '🔴' : '🔵'} {notificationLevel === 'critical' ? 'CRIT' : 'ALL'}
           </button>
         </div>
       </div>

--- a/src/components/BreakingNewsBanner.tsx
+++ b/src/components/BreakingNewsBanner.tsx
@@ -6,9 +6,10 @@ import { Signal } from '@/types';
 interface BreakingNewsBannerProps {
   signals: Signal[];
   onClose?: () => void;
+  notificationLevel?: 'all' | 'critical';
 }
 
-export default function BreakingNewsBanner({ signals, onClose }: BreakingNewsBannerProps) {
+export default function BreakingNewsBanner({ signals, onClose, notificationLevel = 'critical' }: BreakingNewsBannerProps) {
   const [visible, setVisible] = useState(false);
   const [currentIdx, setCurrentIdx] = useState(0);
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
@@ -16,7 +17,7 @@ export default function BreakingNewsBanner({ signals, onClose }: BreakingNewsBan
   const tickerRef = useRef<HTMLDivElement>(null);
 
   const criticals = signals.filter(
-    s => s.severity === 'CRITICAL' && !dismissed.has(s.id)
+    s => (notificationLevel === 'all' ? (s.severity === 'CRITICAL' || s.severity === 'HIGH') : s.severity === 'CRITICAL') && !dismissed.has(s.id)
   );
 
   useEffect(() => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ export interface DashboardSettings {
   refreshInterval: 15 | 30 | 60;
   soundEnabled: boolean;
   trackedRegions: string[];
+  notificationLevel: 'all' | 'critical';
 }
 
 export const DEFAULT_SETTINGS: DashboardSettings = {
@@ -14,6 +15,7 @@ export const DEFAULT_SETTINGS: DashboardSettings = {
   refreshInterval: 30,
   soundEnabled: false,
   trackedRegions: ['Middle East', 'Ukraine', 'Taiwan', 'Korea'],
+  notificationLevel: 'critical',
 };
 
 const AVAILABLE_REGIONS = [
@@ -144,6 +146,40 @@ export default function SettingsModal({ isOpen, onClose, settings, onSettingsCha
                 <BellOff size={12} /> Disabled
               </button>
             </div>
+          </div>
+
+          {/* Push Notification Level */}
+          <div>
+            <label className="block text-[10px] font-mono text-white/40 uppercase tracking-widest mb-2">
+              Push Notifications
+            </label>
+            <div className="flex gap-2">
+              <button
+                onClick={() => update({ notificationLevel: 'critical' })}
+                className={`flex items-center gap-2 px-4 py-2.5 rounded-lg text-[11px] font-mono border transition-all ${
+                  settings.notificationLevel === 'critical'
+                    ? 'bg-[#ff2244]/15 border-[#ff2244]/40 text-[#ff2244]'
+                    : 'bg-white/5 border-white/10 text-white/40 hover:border-white/20 hover:text-white/60'
+                }`}
+              >
+                <Bell size={12} /> Only Critical
+              </button>
+              <button
+                onClick={() => update({ notificationLevel: 'all' })}
+                className={`flex items-center gap-2 px-4 py-2.5 rounded-lg text-[11px] font-mono border transition-all ${
+                  settings.notificationLevel === 'all'
+                    ? 'bg-[#00ccff]/15 border-[#00ccff]/40 text-[#00ccff]'
+                    : 'bg-white/5 border-white/10 text-white/40 hover:border-white/20 hover:text-white/60'
+                }`}
+              >
+                <Bell size={12} /> All Updates
+              </button>
+            </div>
+            <p className="text-[9px] text-white/30 mt-1.5 font-mono">
+              {settings.notificationLevel === 'critical'
+                ? 'Only CRITICAL severity alerts will trigger banners and sounds.'
+                : 'Both CRITICAL and HIGH severity alerts will trigger banners and sounds.'}
+            </p>
           </div>
 
           {/* Tracked Regions */}


### PR DESCRIPTION
- Add notificationLevel state ('all' | 'critical', default 'critical')
- Add quick toggle button in dashboard header bar (🔴 CRIT / 🔵 ALL)
- Add notificationLevel setting in SettingsModal with Only Critical / All Updates buttons
- Wire BreakingNewsBanner to respect notificationLevel (shows HIGH too when ALL)
- Wire alert sound logic to respect notificationLevel (beeps on HIGH too when ALL)
- Same toggle available in War Room view

Purely additive feature. No existing functionality removed.