### PR TITLE
fix: secure API cache-control policy

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,10 @@ const nextConfig = {
         ],
       },
       {
+        source: '/api/:path*',
+        headers: [{ key: 'Cache-Control', value: 'private, no-store' }],
+      },
+      {
         source: '/api/signals',
         headers: [{ key: 'Cache-Control', value: 'public, s-maxage=60, stale-while-revalidate=300' }],
       },
@@ -40,10 +44,6 @@ const nextConfig = {
       {
         source: '/api/flights',
         headers: [{ key: 'Cache-Control', value: 'public, s-maxage=15, stale-while-revalidate=30' }],
-      },
-      {
-        source: '/api/:path*',
-        headers: [{ key: 'Cache-Control', value: 'public, s-maxage=60, stale-while-revalidate=300' }],
       },
       {
         source: '/textures/:path*',


### PR DESCRIPTION
## Summary

Fixes #63 by replacing the blanket public caching policy for API routes with a deny-by-default cache policy.

## Changes

- Changed `/api/:path*` from:
  `public, s-maxage=60, stale-while-revalidate=300`

  to:
  `private, no-store`
- Moved the wildcard rule before the explicit public cache rules.
- Preserved the intended caching behavior for:
  - `/api/signals` — 60s
  - `/api/markets` — 30s
  - `/api/flights` — 15s
- Preserved all unrelated security headers and configuration.
- No API routes or frontend code were modified.

## Security Impact

API endpoints without an explicit public caching policy now default to `private, no-store`.

This prevents sensitive or state-changing API responses such as `/api/notify` from inheriting a public shared-cache policy.

Future API routes will also default to private/no-store unless explicitly added to the public cache allow-list.

## Validation

- `node --check next.config.mjs` — passed
- `git diff --check` — passed
- TypeScript/build validation could not be run because the local `node_modules` installation was unavailable.
- No package files were modified to work around the environment issue.

## Scope

This PR is intentionally limited to `next.config.mjs` and does not alter application behavior or API route implementations.